### PR TITLE
Change module.export syntax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { useNumericSeparator } from './use-numeric-separator';
 
-export const rules = {
-  'use-numeric-separator': useNumericSeparator
+module.exports = {
+  rules: {
+    'use-numeric-separator': useNumericSeparator
+  }
 };


### PR DESCRIPTION
We're getting an error trying to pick this up in best-practices. Could be this.